### PR TITLE
fix: expectRevert on low-level call

### DIFF
--- a/test/benchmark/CoreBenchmark.t.sol
+++ b/test/benchmark/CoreBenchmark.t.sol
@@ -217,7 +217,9 @@ contract CoreBenchmark is Test {
 
     function test_core_callFunction_callback_callbackFunctionRequired() public {
         vm.expectRevert(Core.CallbackFunctionRequired.selector);
-        address(coreWithModulesNoCallback).call(abi.encodeCall(coreWithModulesNoCallback.callbackFunctionOne, ()));
+        (bool revertsAsExpected,) =
+            address(coreWithModulesNoCallback).call(abi.encodeCall(coreWithModulesNoCallback.callbackFunctionOne, ()));
+        vm.assertTrue(revertsAsExpected);
     }
 
 }


### PR DESCRIPTION
According to the [Foundry book](https://book.getfoundry.sh/cheatcodes/expect-revert):

> "Normally, a call that succeeds returns a status of `true` (along with any return data), and a call that reverts returns `false`. The Solidity compiler will insert checks that ensure the call succeeded and revert if it did not. On low-level calls, the `expectRevert` cheatcode works by making the status boolean returned by the low-level call correspond to whether the `expectRevert` succeeded or not, NOT whether or not the low-level call succeeds. Therefore, `status` being false corresponds to the cheatcode failing."

In this testcase, the boolean status was never checked, which caused the test to always pass regardless of whether the call actually succeeded or failed.