### PR TITLE
remove ownableRoles from MintableERC20

### DIFF
--- a/src/module/token/minting/MintableERC20.sol
+++ b/src/module/token/minting/MintableERC20.sol
@@ -34,7 +34,7 @@ library MintableStorage {
 
 }
 
-contract MintableERC20 is OwnableRoles, ModularModule, EIP712, BeforeMintCallbackERC20, IInstallationCallback {
+contract MintableERC20 is ModularModule, EIP712, BeforeMintCallbackERC20, IInstallationCallback {
 
     using ECDSA for bytes32;
 


### PR DESCRIPTION
OwnableRoles is not needed to be inherited in this scenario as it's being directly referenced as such:
`OwnableRoles(address(this)).method`