### PR TITLE
update batchMetadata logic to make each batchUris independent

### DIFF
--- a/src/module/token/metadata/BatchMetadataERC721.sol
+++ b/src/module/token/metadata/BatchMetadataERC721.sol
@@ -162,7 +162,7 @@ contract BatchMetadataERC721 is Module {
         for (uint256 i = 0; i < numOfBatches; i += 1) {
             if (_tokenId < rangeEnds[i]) {
                 uint256 rangeStart = 0;
-                if(i > 0) {
+                if (i > 0) {
                     rangeStart = rangeEnds[i - 1];
                 }
                 return (_batchMetadataStorage().baseURIOfTokenIdRange[rangeEnds[i]], _tokenId - rangeStart);

--- a/test/module/metadata/BatchMetadataERC1155.t.sol
+++ b/test/module/metadata/BatchMetadataERC1155.t.sol
@@ -58,8 +58,8 @@ contract BatchMetadataERC1155Test is Test {
         // read state from core
         assertEq(core.uri(1), "ipfs://base/1");
         assertEq(core.uri(99), "ipfs://base/99");
-        assertEq(core.uri(100), "ipfs://base2/100");
-        assertEq(core.uri(199), "ipfs://base2/199");
+        assertEq(core.uri(100), "ipfs://base2/0");
+        assertEq(core.uri(199), "ipfs://base2/99");
     }
 
     function test_revert_uploadMetadata() public {

--- a/test/module/metadata/BatchMetadataERC721.t.sol
+++ b/test/module/metadata/BatchMetadataERC721.t.sol
@@ -58,8 +58,8 @@ contract BatchMetadataERC721Test is Test {
         // read state from core
         assertEq(core.tokenURI(1), "ipfs://base/1");
         assertEq(core.tokenURI(99), "ipfs://base/99");
-        assertEq(core.tokenURI(100), "ipfs://base2/100");
-        assertEq(core.tokenURI(199), "ipfs://base2/199");
+        assertEq(core.tokenURI(100), "ipfs://base2/0");
+        assertEq(core.tokenURI(199), "ipfs://base2/99");
     }
 
     function test_revert_uploadMetadata() public {


### PR DESCRIPTION
The client should NOT care what next token id is when uploading metadata. Each batch should be independent: 

batch1: `baseUri_1/0`, `baseUri_1/1` etc. 
batch2: `baseUri_2/0`, `baseUri_2/1` etc. 

to get the index within the batch:

batchIndex = tokenId - batch range start